### PR TITLE
Handle entity arrays in adventure entity migration

### DIFF
--- a/assets-sync.js
+++ b/assets-sync.js
@@ -1341,12 +1341,7 @@ class EntityMigration {
                 for (const type of ['actors', 'combats', 'items', 'scenes',
                                     'journal', 'tables', 'macros', 'cards',
                                     'playlists', 'folders']) {
-                    data[type] = await this.migrateEntity(type, data[type]);
-                    if (Array.isArray(data[type])) {
-                        data[type] = await this.constructor.mapAsync(data[type], entity => this.migrateEntity(type, entity));
-                    } else {
-                        data[type] = await this.migrateEntity(type, data[type]);
-                    }
+                    data[type] = await this.constructor.mapAsync(data[type], entity => this.migrateEntity(type, entity));
                 }
                 break;
             case 'Card':

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -1342,6 +1342,11 @@ class EntityMigration {
                                     'journal', 'tables', 'macros', 'cards',
                                     'playlists', 'folders']) {
                     data[type] = await this.migrateEntity(type, data[type]);
+                    if (Array.isArray(data[type])) {
+                        data[type] = await this.constructor.mapAsync(data[type], entity => this.migrateEntity(type, entity));
+                    } else {
+                        data[type] = await this.migrateEntity(type, data[type]);
+                    }
                 }
                 break;
             case 'Card':


### PR DESCRIPTION
Adventure data can exist as an array of other entities, but is currently not being handled correctly during entity path migration