### PR TITLE
Remove null values in changes object recursively

### DIFF
--- a/assets-sync.js
+++ b/assets-sync.js
@@ -1311,6 +1311,19 @@ class WorldMigration {
         })
         const changes = migrated.filter(d => !!d);
         if (changes.length) {
+            const removeNullProperties = (obj) => {
+                for (const key in obj) {
+                    if (obj[key] === null) {
+                        delete obj[key];
+                    } else if (typeof obj[key] === 'object' && obj[key] !== null) {
+                        // Recurse into nested objects
+                        removeNullProperties(obj[key]);
+                    }
+                }
+                return obj;
+            }
+            // Prevent any possible null update errors in Foundry
+            removeNullProperties(changes);
             const klass = CONFIG[type].documentClass || CONFIG[type].entityClass;  // v9 vs 0.8.x
             const updateMethod =  (klass.updateDocuments || klass.update).bind(klass); // v9 vs 0.8.x
             try {


### PR DESCRIPTION
Asset Sync side fix for https://github.com/foundryvtt/foundryvtt/issues/9938 and [Forum Ticket](https://forums.forge-vtt.com/t/asset-sync-not-updating-scene-background-foreground-to-local-files/88831/10)

We can avoid the error by removing null updates which may arise due to lazy loading or other behaviour which may be hidden by the stringify of the original entity data.