### PR TITLE
Improve robustness of asset sync

### DIFF
--- a/assets-sync.js
+++ b/assets-sync.js
@@ -500,7 +500,7 @@
     async buildLocalInventory(referenceDirs) {
         referenceDirs = referenceDirs || new Set();
         // Add the root dir to the reference list
-        referenceDirs.add("/");
+        referenceDirs.add(this.apiKeyPath ? this.apiKeyPath : "/");
 
         const localFileSet = new Set();
         const localDirSet = new Set();
@@ -517,7 +517,7 @@
                 if (!fp || decodeURIComponent(fp.target) !== dir) continue;
 
                 localDirSet.add(dir);
-                fp.files.forEach(f => localFileSet.add(f));
+                fp.files.forEach(f => localFileSet.add(decodeURIComponent(f)));
             } catch (error) {
                 const errorMessage = error.message || error;
                 if (errorMessage?.match("does not exist")) continue;

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -360,8 +360,6 @@
                 return false;
             }
         }
-        
-        return true;
     }
 
     /**
@@ -747,7 +745,7 @@
      * @param {String} path 
      */
     async createDirectory(path, {retries=0}={}) {
-        path = path.replace(/\/+$|^\//g, "").replace(/\/+/g, "/");
+        path = path.replace(/\/+$|^\/+/g, "").replace(/\/+/g, "/");
 
         const pathParts = path.split("/");
         let created = 0;

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -226,8 +226,6 @@
             throw Error(`Forge VTT | Asset Sync could not process assets`);
         }
 
-        const synced = [];
-        const failed = [];
         let assetIndex = 1;
 
         this.app.updateProgress({current: 0, name: "", total: assets.size, step: "Synchronizing assets", type: "Asset"});
@@ -258,19 +256,19 @@
                 // If all is good, mark the asset as synced
                 // @todo maybe predicate this on receiving a "true" from previous methods?
                 if (!!result)
-                    synced.push(asset);
+                    this.syncedAssets.push(asset);
                 else
-                    failed.push(asset);
+                    this.failedAssets.push(asset);
             } catch (error) {
                 console.warn(error);
                 // If any errors occured mark the asset as failed and move on
-                failed.push(asset);
+                this.failedAssets.push(asset);
             }
 
             assetIndex++;
         }
 
-        return {synced, failed}
+        return {synced: this.syncedAssets, failed: this.failedAssets};
     }
 
     _updateAssetMapping(asset, etag) {
@@ -953,6 +951,8 @@ class ForgeAssetSyncApp extends FormApplication {
             syncProgress: this.syncProgress,
             syncStatusIcon: this.syncStatusIcon,
             syncStatusIconClass: iconClass,
+            failedFolders: this.syncWorker?.failedFolders ?? [],
+            failedAssets: (this.syncWorker?.failedAssets ?? []).map(a => a.name),
         }
     }
 

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -254,7 +254,6 @@
                 this.app.updateProgress({current: assetIndex, name: asset.name});
 
                 // If all is good, mark the asset as synced
-                // @todo maybe predicate this on receiving a "true" from previous methods?
                 if (!!result)
                     this.syncedAssets.push(asset);
                 else
@@ -528,7 +527,6 @@
     /**
      * Use Fetch API to get the etag header from a local file
      * @param {*} path 
-     * @todo add error handling
      */
     static async fetchLocalEtag(path) {
         const headers = new Headers();

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -35,7 +35,7 @@
         POSTSYNC: `Cleaning up Sync Data`,
         DBREWRITE: `Updating game to use local assets...`,
         COMPLETE: `Sync Completed Successfully!`,
-        WITHERRORS: `Sync Completed with Errors. Check console for more details.`,
+        WITHERRORS: `Sync Completed with Errors. See below for folders and files which could not be synced. Check console for more details.`,
         FAILED: `Failed to Sync. Check console for more details.`,
         UNAUTHORIZED: `Unauthorized. Please check your API Key and try again.`,
         CANCELLED: `Sync process Cancelled`,
@@ -936,7 +936,7 @@ class ForgeAssetSyncApp extends FormApplication {
         if (this.syncStatusIcon === "failed")
           iconClass = "fas fa-times";
         if (this.syncStatusIcon === "witherrors")
-          iconClass = "fas fa-exclamation";
+          iconClass = "fas fa-exclamation-triangle";
         
         const syncButtonText = this.isSyncing ? "Cancel" : "Sync";
         const syncButtonIcon = this.isSyncing ? "fas fa-ban" : "fas fa-sync";

--- a/assets-sync.js
+++ b/assets-sync.js
@@ -533,13 +533,17 @@
     static async fetchLocalEtag(path) {
         const headers = new Headers();
         let etag;
-        const request = await fetch(`/${encodeURL(path)}`, {
-            method: "HEAD",
-            headers
-        });
+        try {
+            const request = await fetch(`/${encodeURL(path)}`, {
+                method: "HEAD",
+                headers
+            });
 
-        etag = request?.headers?.get("etag");
-
+            etag = request?.headers?.get("etag");
+        } catch (error) {
+            console.warn(error);
+            return;
+        }
         return etag;
     }
 

--- a/styles/forgevtt.css
+++ b/styles/forgevtt.css
@@ -85,7 +85,19 @@ button img.forge-vtt-icon {
 #forgevtt-asset-sync div.options .form-group label span {
     vertical-align: top;
 }
-  
+
+#forgevtt-asset-sync .failures {
+    margin-top: 5px;
+    padding: 0.5em;
+    border: 1px solid rgba(0,0,0,0.5);
+    border-radius: 5px;
+}
+
+#forgevtt-asset-sync .failures ul {
+    color: #990000;
+    margin-bottom: 1em;
+}
+
 @keyframes spin {
     to { -webkit-transform: rotate(360deg); }
 }

--- a/styles/forgevtt.css
+++ b/styles/forgevtt.css
@@ -94,7 +94,7 @@ button img.forge-vtt-icon {
 }
 
 #forgevtt-asset-sync .failures ul {
-    color: #990000;
+    color: var(--color-level-error);
     margin-bottom: 1em;
 }
 

--- a/templates/asset-sync-form.hbs
+++ b/templates/asset-sync-form.hbs
@@ -52,6 +52,26 @@
     </div>
     <footer>
       <button type="button" name="sync" class="sync"><i class="{{syncButtonIcon}}"></i> {{syncButtonText}}</button>
+      {{#if (or failedFolders.length failedAssets.length)}}
+        <div class="failures">
+        {{#if failedFolders.length}}
+          <h3>Failed Folders:</h3>
+          <ul>
+            {{#each failedFolders}}
+            <li>{{this}}</li>
+            {{/each}}
+          </ul>
+        {{/if}}
+        {{#if failedAssets.length}}
+          <h3>Failed Assets:</h3>
+          <ul>
+            {{#each failedAssets}}
+            <li>{{this}}</li>
+            {{/each}}
+          </ul>
+        {{/if}}
+        </div>
+      {{/if}}
     </footer>
   {{/if}}
 </form>

--- a/templates/asset-sync-form.hbs
+++ b/templates/asset-sync-form.hbs
@@ -55,7 +55,7 @@
       {{#if (or failedFolders.length failedAssets.length)}}
         <div class="failures">
         {{#if failedFolders.length}}
-          <h3>Failed Folders:</h3>
+          <h3><i class="fas fa-exclamation-triangle"></i> Failed Folders:</h3>
           <ul>
             {{#each failedFolders}}
             <li>{{this}}</li>
@@ -63,7 +63,7 @@
           </ul>
         {{/if}}
         {{#if failedAssets.length}}
-          <h3>Failed Assets:</h3>
+          <h3><i class="fas fa-exclamation-triangle"></i> Failed Assets:</h3>
           <ul>
             {{#each failedAssets}}
             <li>{{this}}</li>


### PR DESCRIPTION
Closes #14.

This PR includes the following updates:
- Continue asset sync if some folders failed to be created.
- Skip assets in folders which are missing locally.
- Make use of the existing but unused `failedFolders` and `failedAsses` variables.
- Display the list of failed folders and assets in the UI, update the "failed with errors" message.
- Fix a bug which would cause asset sync with a non-root-folder API key to attempt to sync the root folder of the target Assets Library instead of the base folder of the API key.
- Fix a cause of mismatches between local and Forge assets due to un-decoded URLs.