### PR TITLE
Use encodeURIComponent to avoid directory name mismatches

### DIFF
--- a/assets-sync.js
+++ b/assets-sync.js
@@ -505,7 +505,7 @@
         // use filepicker.browse to check in the paths provided in referenceassets
         for (const dir of referenceDirs) {
             try {
-                const fp = await FilePicker.browse("data", dir);
+                const fp = await FilePicker.browse("data", encodeURIComponent(dir));
                 this.app.updateProgress({current: dirIndex, name: dir});
                 
                 dirIndex++;
@@ -759,7 +759,7 @@
 
             if (!pathExists) {
                 try {
-                    await FilePicker.createDirectory("data", subPath);
+                    await FilePicker.createDirectory("data", encodeURIComponent(subPath));
                     this.localInventory.localDirSet.add(subPath);
                     created++;
                     continue; // Don't return yet, we may still need to check the rest of the path


### PR DESCRIPTION
Follow up to #16. This passes directory names through `encodeURIComponent` before `FilePicker` operations so that HTML escape sequences in the actual file name aren't interpreted incorrectly.

With this fix, the only failures from my test folder are those which don't match Foundry's allowed file types. Compare with Phi's screenshot in #16.
![image](https://github.com/ForgeVTT/fvtt-module-forge-vtt/assets/49248157/da0390d7-98b5-4488-9acb-8cb73f691b6d)
