### PR TITLE
Revert "Check v11 file types before upload"

### DIFF
--- a/assets-sync.js
+++ b/assets-sync.js
@@ -719,13 +719,6 @@
         if (!asset.name) throw new Error(`Forge VTT | Asset with URL ${asset.url} has no name and cannot be uploaded.`);
         if (asset.name.endsWith("/")) throw new Error(`Forge VTT | Asset with URL ${asset.url} appears to be a folder.`);
         if (!blob) throw new Error(`Forge VTT | No Blob data provided for ${asset.name} and therefore it cannot be uploaded to Foundry.`);
-        if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
-            // v11 now provides a list of uploadable file types. If we're on v11, check that the file is allowed.
-            const isAllowedType = Object.values(CONST.UPLOADABLE_FILE_EXTENSIONS).includes(blob.type);
-            if (!isAllowedType) {
-                throw new Error(`Forge VTT | ${asset.name} is not a Foundry uploadable file type and will not be synced.`);
-            }
-        }
 
         try {
             const nameParts = asset.name.split("/");


### PR DESCRIPTION
This reverts commit 91ccec7d922125d9087bf65f0282c16e5605dad5.

Error handling takes care of cases where assets are not uploadable and these no longer need to be expressly skipped