### PR TITLE
Fix `ForgeVTT_FilePicker` error on v7 and earlier

### DIFF
--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -2048,7 +2048,7 @@ class ForgeVTT_FilePicker extends FilePicker {
     static _getForgeVttBucket(bucketKey) {
         const buckets = this._getForgeVTTBuckets();
         // From Foundry v12, buckets are keyed by index not by hash
-        const isHashKey = isNaN(bucketKey) || !foundry.utils.isNewerVersion(ForgeVTT.foundryVersion, "12");
+        const isHashKey = isNaN(bucketKey) || !isNewerVersion(ForgeVTT.foundryVersion, "12");
         const bucketIndex = isHashKey ? buckets.findIndex((b) => b.key === bucketKey) : bucketKey;
         return buckets[bucketIndex];
     }
@@ -2061,7 +2061,7 @@ class ForgeVTT_FilePicker extends FilePicker {
      */
     _getBucketKey(bucket) {
         const buckets = this.constructor._getForgeVTTBuckets();
-        return foundry.utils.isNewerVersion(ForgeVTT.foundryVersion, "12")
+        return isNewerVersion(ForgeVTT.foundryVersion, "12")
             ? buckets.findIndex((b) => b.key === bucket.key)
             : bucket.key;
     }

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -98,7 +98,6 @@ class ForgeVTT {
         return !obj || typeof(obj) !== "object" || Object.keys(obj).length === 0;
     }
 
-    static hasFoundryGlobal = null;
     /**
      * The global isNewerVersion will be removed in v14, so we need a utility function to alias to whichever is available.
      * @param {string} version The version to check
@@ -106,23 +105,9 @@ class ForgeVTT {
      * @returns {boolean} True when the version is newer than the target, false otherwise
      */
     static isNewerVersion(version, target) {
-        if (this.hasFoundryGlobal !== null) {
-            if (this.hasFoundryGlobal) {
-                return foundry.utils.isNewerVersion(version, target);
-            } else {
-                return isNewerVersion(version, target);
-            }
-        }
-        // this.hasFoundryGlobal hasn't been set yet, so we need to check if the global foundry object exists
         try {
-            if (foundry && foundry.utils && foundry.utils.isNewerVersion) {
-                this.hasFoundryGlobal = true;
-                return foundry.utils.isNewerVersion(version, target);
-            } else {
-                return isNewerVersion(version, target);
-            }
-        } catch (err) {
-            this.hasFoundryGlobal = false;
+            return foundry.utils.isNewerVersion(version, target);
+        } catch (_) {
             return isNewerVersion(version, target);
         }
     }

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -98,15 +98,30 @@ class ForgeVTT {
         return !obj || typeof(obj) !== "object" || Object.keys(obj).length === 0;
     }
 
+    static hasFoundryGlobal = null;
     /**
      * The global isNewerVersion will be removed in v14, so we need a utility function to alias to whichever is available.
      * @param {string} version 
      * @param {string} target 
      */
     static isNewerVersion(version, target) {
-        if (foundry?.utils) {
-            return foundry.utils.isNewerVersion(version, target);
-        } else {
+        if (this.hasFoundryGlobal !== null) {
+            if (this.hasFoundryGlobal) {
+                return foundry.utils.isNewerVersion(version, target);
+            } else {
+                return isNewerVersion(version, target);
+            }
+        }
+        // this.hasFoundryGlobal hasn't been set yet, so we need to check if the global foundry object exists
+        try {
+            if (foundry && foundry.utils && foundry.utils.isNewerVersion) {
+                this.hasFoundryGlobal = true;
+                return foundry.utils.isNewerVersion(version, target);
+            } else {
+                return isNewerVersion(version, target);
+            }
+        } catch (err) {
+            this.hasFoundryGlobal = false;
             return isNewerVersion(version, target);
         }
     }

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -101,8 +101,9 @@ class ForgeVTT {
     static hasFoundryGlobal = null;
     /**
      * The global isNewerVersion will be removed in v14, so we need a utility function to alias to whichever is available.
-     * @param {string} version 
-     * @param {string} target 
+     * @param {string} version The version to check
+     * @param {string} target The version to check against
+     * @returns {boolean} True when the version is newer than the target, false otherwise
      */
     static isNewerVersion(version, target) {
         if (this.hasFoundryGlobal !== null) {

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -97,6 +97,20 @@ class ForgeVTT {
     static isObjectEmpty(obj) {
         return !obj || typeof(obj) !== "object" || Object.keys(obj).length === 0;
     }
+
+    /**
+     * The global isNewerVersion will be removed in v14, so we need a utility function to alias to whichever is available.
+     * @param {string} version 
+     * @param {string} target 
+     */
+    static isNewerVersion(version, target) {
+        if (foundry?.utils) {
+            return foundry.utils.isNewerVersion(version, target);
+        } else {
+            return isNewerVersion(version, target);
+        }
+    }
+
     static init() {
         /* Test for Foundry bug where world doesn't load. Can be worse in 0.8.x and worse even if user has duplicate packs */
         if (window.location.pathname == "/game" && this.isObjectEmpty(game.data)) {
@@ -173,7 +187,7 @@ class ForgeVTT {
                 }
             }
             // Foundry 0.8.x
-            if (isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
                 // we need to do this for BaseActor and BaseMacro as well because they override the two methods but don't call `super`
                 for (const klass of [foundry.abstract.Document, foundry.documents.BaseActor, foundry.documents.BaseMacro]) {
                     const preCreate = klass.prototype._preCreate;
@@ -187,7 +201,7 @@ class ForgeVTT {
                         return preUpdate.call(this, ...arguments);
                     }
                 }
-            } else if (isNewerVersion(ForgeVTT.foundryVersion, "0.7.0")) {
+            } else if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.7.0")) {
                 const create = Entity.create;
                 Entity.create = async function (data, options) {
                     await ForgeVTT.findAndDestroyDataImages(this.entity, data).catch(err => {});
@@ -219,13 +233,13 @@ class ForgeVTT {
                 // connection from the server side, we instead hijack the `Setup.post` on the client side so if a package is installed
                 // successfully and synchronsouly (a Bazaar install, not a protected content), we can fake a progress report
                 // of step "Package" which vends the API result.
-                if (isNewerVersion(ForgeVTT.foundryVersion, "9")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "9")) {
                     const origPost = Setup.post;
                     Setup.post = async function (data, ...args) {
                         const request = await origPost.call(this, data, ...args);
                         if (data.action === "installPackage") {
                             let response;
-                            if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+                            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                                 // In v11, Setup.post() returns an object, not a Response
                                 response = request;
                             } else {
@@ -242,13 +256,13 @@ class ForgeVTT {
                                     name: data.name,
                                     type: data.type || "module",
                                     pct: 100,
-                                    pkg: isNewerVersion(ForgeVTT.foundryVersion, "10") ? response.data : response,
+                                    pkg: ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10") ? response.data : response,
                                     // The term that represents the "vend" step may change with FVTT versions
-                                    step: isNewerVersion(ForgeVTT.foundryVersion, "11") ? CONST.SETUP_PACKAGE_PROGRESS.STEPS.VEND : "Package",
+                                    step: ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11") ? CONST.SETUP_PACKAGE_PROGRESS.STEPS.VEND : "Package",
                                     // v11 checks the response manifest against what is passed
                                     manifest: data.manifest,
                                 };
-                                if (isNewerVersion(ForgeVTT.foundryVersion, "12")) {
+                                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "12")) {
                                     // In v12, _onProgress expects id = manifest and step = "complete"
                                     onProgressRsp.step = CONST.SETUP_PACKAGE_PROGRESS.STEPS.COMPLETE;
                                     onProgressRsp.id = data.manifest;
@@ -283,7 +297,7 @@ class ForgeVTT {
                     setup.element[0].style.top = setup.element[0].style.left = ""
                     setup.setPosition({height: "auto"});
                 });
-                if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                     // v11 requires that we export worlds before migration if on Forge so that we can set deleteNEDB
                     // This removes unused NEDB databases from pre-v11 worlds which would otherwise swell user data use
                     Hooks.on("renderSetupPackages", (setup, html) => {
@@ -425,7 +439,7 @@ class ForgeVTT {
                 ForgeVTT.ensureIsJQuery(html)
                     .find("label[for=remote]")
                     .html(`<i class="fas fa-share-alt"></i> Game URL`);
-                if (isNewerVersion(ForgeVTT.foundryVersion, "9.0")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "9.0")) {
                     ForgeVTT.ensureIsJQuery(html).find(".show-hide").remove();
                     ForgeVTT.ensureIsJQuery(html).find("#remote-link").attr("type", "text").css({"flex": "3"});
                 }
@@ -450,7 +464,7 @@ class ForgeVTT {
                     default:
                         break;
                 }
-                if (isNewerVersion(ForgeVTT.foundryVersion, "10") ) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10") ) {
                     if (!changed.prototypeToken?.texture?.src) {
                         if (!actor.prototypeToken?.texture?.src || defaultTokenImages.includes(actor.prototypeToken?.texture?.src)) {
                             setProperty(changed, "prototypeToken.texture.src", changed.img);
@@ -498,7 +512,7 @@ class ForgeVTT {
         // System specific overrides for when additional Forge logic is necessary
         // This needs to run in game when the game.system.id is known (it is undefined in /setup and /join screens)
         //  and it needs to be run before the Foundry setup hook, because the system initializes before the setup hook
-        if (isNewerVersion(ForgeVTT.foundryVersion, '10') && game?.system?.id) {
+        if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, '10') && game?.system?.id) {
             switch (game.system.id) {
                 case 'pf2e':
                     // pf2e system changes token default-icons to the actor image, but does not handle Assets Library paths
@@ -535,7 +549,7 @@ class ForgeVTT {
     }
 
     static async setup() {
-        const isNewerThanV10 = isNewerVersion(ForgeVTT.foundryVersion, "10");
+        const isNewerThanV10 = ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10");
         this.injectForgeModules();
 
         // Remove the progress bar once setup has been called as the interface is being visibly built at that point
@@ -550,7 +564,7 @@ class ForgeVTT {
             // Fix Infinite duration on some uncached audio files served by Cloudflare,
             // See https://gitlab.com/foundrynet/foundryvtt/-/issues/5869#note_754029249
             // Only override this on 0.8.x and v9 as this bug should presumably be fixed in v10
-            if (isNewerVersion(ForgeVTT.foundryVersion, "0.8.0") && !isNewerThanV10) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.8.0") && !isNewerThanV10) {
                 const original = AudioContainer.prototype._createAudioElement;
                 AudioContainer.prototype._createAudioElement = async function(...args) {
                     const element = await original.call(this, ...args);
@@ -612,13 +626,13 @@ class ForgeVTT {
         const liveKitModule = game.modules.get('avclient-livekit');
         if (this.usingTheForge && liveKitModule?.active) {
             const liveKitModuleVersion = isNewerThanV10 ? liveKitModule.version : liveKitModule.data.version;
-            if (isNewerVersion(liveKitModuleVersion, "0.5")) {
+            if (ForgeVTT.isNewerVersion(liveKitModuleVersion, "0.5")) {
                 // hook on liveKitClientAvailable in 0.5.2+ as it gets called earlier and fixes issues seeing the Forge option if A/V isn't enabled yet
-                const hookName = isNewerVersion(liveKitModuleVersion, "0.5.1") ? "liveKitClientAvailable" : "liveKitClientInitialized";
+                const hookName = ForgeVTT.isNewerVersion(liveKitModuleVersion, "0.5.1") ? "liveKitClientAvailable" : "liveKitClientInitialized";
                 // Foundry creates the client and connects it immediately without any hooks or anything to let us act on it
                 // So we need to set this up on the client class itself in the setup hook before webrtc is configured
                 Hooks.once(hookName, (client) => {
-                    const liveKitClient = isNewerVersion(liveKitModuleVersion, "0.5.1") ? client : client._liveKitClient;
+                    const liveKitClient = ForgeVTT.isNewerVersion(liveKitModuleVersion, "0.5.1") ? client : client._liveKitClient;
                     liveKitClient.addLiveKitServerType({
                         key: "forge",
                         label: "The Forge",
@@ -662,7 +676,7 @@ class ForgeVTT {
             if (status.invitation)
                 game.data.addresses.local = `${this.FORGE_URL}/invite/${this.gameSlug}/${status.invitation}`;
             game.data.addresses.remote = this.GAME_URL;
-            if (isNewerVersion(ForgeVTT.foundryVersion, "9.0"))
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "9.0"))
                 game.data.addresses.remoteIsAccessible = true;
             if (status.announcements)
                 this._handleAnnouncements(status.announcements);
@@ -681,7 +695,7 @@ class ForgeVTT {
                     });
                 this._addJoinGameAs();
             }
-            if (isNewerVersion(ForgeVTT.foundryVersion, "10")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10")) {
                 // On v10, make The Forge module appear enabled
                 const moduleConfiguration = game.settings.get("core", "moduleConfiguration");
                 if (!moduleConfiguration["forge-vtt"]) {
@@ -778,8 +792,8 @@ class ForgeVTT {
                 unavailable: false
             };
             let moduleData = data;
-            if (isNewerVersion(ForgeVTT.foundryVersion, "10")) {
-                if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                     // Since v11, Foundry will create availability (from compatibility), but only if it doesn't exist
                     delete data.availability;
                 }
@@ -796,7 +810,7 @@ class ForgeVTT {
                 // v10 will display it in the manage modules section, so we should make it a requirement of the world.
                 game.world.relationships.requires.add({type: "module", id: "forge-vtt"});
             } else {
-                if (isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
                     moduleData = new foundry.packages.ModuleData(data);
                 }
                 let module = {
@@ -817,7 +831,7 @@ class ForgeVTT {
                 game.modules.set('forge-vtt', module);
             }
         }
-        if (!game.modules.get('forge-vtt-optional') && isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
+        if (!game.modules.get('forge-vtt-optional') && ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.8.0")) {
             const settings = game.settings.get("core", ModuleManagement.CONFIG_SETTING) || {};
 
             const data = {
@@ -847,8 +861,8 @@ class ForgeVTT {
                 availability: 0, // Shows as a red warning in the module list from v11 onwards, see below
                 unavailable: false
             };
-            if (isNewerVersion(ForgeVTT.foundryVersion, "10")) {
-                if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                     // Since v11, Foundry will create availability (from compatibility), but only if it doesn't exist
                     delete data.availability;
                 }
@@ -949,10 +963,10 @@ class ForgeVTT {
         if (!html) {
             joinForm = $("#join-form");
         } else {
-            if (isNewerVersion(ForgeVTT.foundryVersion, "12")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "12")) {
                 // Foundry v12 sets the #join-game-form id but doesn't have a specific join-form class
                 joinForm = $(ForgeVTT.ensureIsJQuery(html).find("#join-game-form > footer")[0]);
-            } else if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+            } else if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                 // Foundry v11 sets a specific join-form class we can search for
                 joinForm = $(ForgeVTT.ensureIsJQuery(html).find(".join-form > footer")[0]);
             } else {
@@ -967,7 +981,7 @@ class ForgeVTT {
         // Add return to setup
         if (status.isOwner && status.table) {
             const button = $(`<button type="button" name="back-to-setup"><i class="fas fa-home"></i> Return to Setup</button>`);
-            if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+            if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                 // v11+ sets specific styling for join form buttons
                 button.css({ "min-width" : "100%" }); // Let buttons take up all horizontal space
                 button.addClass('bright'); // v11 themes, 'bright'
@@ -983,7 +997,7 @@ class ForgeVTT {
         // Add return to the forge
         const forgevtt_button = $(`<button type="button" name="back-to-forge-vtt"><i class="fas fa-hammer"></i> Back to The Forge</button>`);
         forgevtt_button.click(() => window.location = `${this.FORGE_URL}/games`);
-        if (isNewerVersion(ForgeVTT.foundryVersion, "11")) forgevtt_button.addClass('bright'); // v11 themes, 'bright'
+        if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) forgevtt_button.addClass('bright'); // v11 themes, 'bright'
         joinForm.append(forgevtt_button)
         // Remove "Return to Setup" section from login screen when the game is not of type Table.
         if (!status.table || status.isOwner) {
@@ -991,10 +1005,10 @@ class ForgeVTT {
             if (!html) {
                 shutdown = $("form#shutdown");
             } else {
-                if (isNewerVersion(ForgeVTT.foundryVersion, "12")) {
+                if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "12")) {
                     // Foundry v12 sets a join-game-setup id we can search for
                     shutdown = $(ForgeVTT.ensureIsJQuery(html).find("#join-game-setup")[0]);
-                } else if (isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+                } else if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
                     // Foundry v11 sets a specific return-setup class we can search for
                     shutdown = $(ForgeVTT.ensureIsJQuery(html).find("div .return-setup")[0]);
                 } else {
@@ -1029,7 +1043,7 @@ class ForgeVTT {
     static _joinGameAs() {
         const options = [];
         // Could be logged in as someone else
-        const gameusers = (isNewerVersion(ForgeVTT.foundryVersion, "9.0") ? game.users : game.users.entities);
+        const gameusers = (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "9.0") ? game.users : game.users.entities);
         if (ForgeAPI.lastStatus.isGM && !this._getUserFlag(game.user, "temporary")) {
 
             const myUser = gameusers.find(user => this._getUserFlag(user, "player") === ForgeAPI.lastStatus.user) || game.user;
@@ -1432,9 +1446,9 @@ class ForgeVTT {
     static get FILE_EXTENSIONS() {
         const extensions = ["pdf", "json"]; // Some extensions that modules use that aren't part of the core media extensions
         // Add media file extensions
-        if (isNewerVersion(ForgeVTT.foundryVersion, "10")) {
+        if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "10")) {
             extensions.push(...Object.keys(CONST.UPLOADABLE_FILE_EXTENSIONS))
-        } else if (isNewerVersion(ForgeVTT.foundryVersion, "9.0")) {
+        } else if (ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "9.0")) {
             extensions.push(...Object.keys(CONST.AUDIO_FILE_EXTENSIONS),
                             ...Object.keys(CONST.IMAGE_FILE_EXTENSIONS),
                             ...Object.keys(CONST.VIDEO_FILE_EXTENSIONS));
@@ -1745,7 +1759,7 @@ class ForgeAPI {
 class ForgeVTT_FilePicker extends FilePicker {
     constructor(...args) {
         super(...args);
-        this._newFilePicker = isNewerVersion(ForgeVTT.foundryVersion, "0.5.5");
+        this._newFilePicker = ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "0.5.5");
         this._deferredPopulateForgeBuckets = !ForgeAPI.lastStatus;
         this._inferCurrentDirectoryAndSetSource(this.request);
     }
@@ -2048,7 +2062,7 @@ class ForgeVTT_FilePicker extends FilePicker {
     static _getForgeVttBucket(bucketKey) {
         const buckets = this._getForgeVTTBuckets();
         // From Foundry v12, buckets are keyed by index not by hash
-        const isHashKey = isNaN(bucketKey) || !isNewerVersion(ForgeVTT.foundryVersion, "12");
+        const isHashKey = isNaN(bucketKey) || !ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "12");
         const bucketIndex = isHashKey ? buckets.findIndex((b) => b.key === bucketKey) : bucketKey;
         return buckets[bucketIndex];
     }
@@ -2061,7 +2075,7 @@ class ForgeVTT_FilePicker extends FilePicker {
      */
     _getBucketKey(bucket) {
         const buckets = this.constructor._getForgeVTTBuckets();
-        return isNewerVersion(ForgeVTT.foundryVersion, "12")
+        return ForgeVTT.isNewerVersion(ForgeVTT.foundryVersion, "12")
             ? buckets.findIndex((b) => b.key === bucket.key)
             : bucket.key;
     }


### PR DESCRIPTION
The `foundry` global was added in Foundry 0.8. These changes use the globally available `isNewerVersion` function instead of `foundry.utils.isNewerVersion`, so that backward compatibility with v7 and earlier is preserved.

Related to https://github.com/ForgeVTT/theforge/issues/2012. Main repo will also need a PR to update this submodule in order to close the issue.