### PR TITLE
Add buckets value to getData for forgevtt source

### DIFF
--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -1817,6 +1817,7 @@ class ForgeVTT_FilePicker extends FilePicker {
         if (this.activeSource === "forgevtt" && data.source.buckets.length > 1) {
             data.isS3 = true;
             data.bucket = data.source.bucket;
+            data.buckets = data.source.buckets;
         }
         return data;
     }


### PR DESCRIPTION
Adds `data.buckets = data.source.buckets;` for forgevtt source which supplies the data sent to the FilePicker template for rendering