### PR TITLE
Override `Setup.post` on Foundry v13

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style = space
+indent_size = 4

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -346,6 +346,7 @@ class ForgeVTT {
                     },
                 );
 
+                // Starting in v13, this is the new hook for rendering the settings window
                 Hooks.on("renderServerSettingsConfig", (setup, html) => {
                     // Remove all form groups except the one that has the telemetry input
                     ForgeVTT.ensureIsJQuery(html)

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -329,17 +329,45 @@ class ForgeVTT {
                 });
 
                 // v11 requires that we keep the setup-configuration button active but allow only telemetry to be set
-                Hooks.on('renderSetupApplicationConfiguration', (setup, html) => {
+                Hooks.on(
+                    "renderSetupApplicationConfiguration",
+                    (setup, html) => {
+                        // Remove all form groups except the one that has the telemetry input
+                        ForgeVTT.ensureIsJQuery(html)
+                            .find(".form-group")
+                            .not(
+                                ":has(input[name=telemetry]), :has(select[name=cssTheme])",
+                            )
+                            .remove();
+                        // Adjust style properties so the window appears in the middle of the screen rather than very top
+                        setup.element[0].style.top =
+                            setup.element[0].style.left = "";
+                        setup.setPosition({ height: "auto" });
+                    },
+                );
+
+                Hooks.on("renderServerSettingsConfig", (setup, html) => {
                     // Remove all form groups except the one that has the telemetry input
                     ForgeVTT.ensureIsJQuery(html)
                         .find(".form-group")
-                        .not(":has(input[name=telemetry]), :has(select[name=cssTheme])")
+                        .not(
+                            ":has(input[name=telemetry]), :has(select[name=cssTheme])",
+                        )
                         .remove();
+                    // Remove fieldsets without fields
+                    ForgeVTT.ensureIsJQuery(html)
+                        .find("fieldset:not(:has(.form-group))")
+                        .remove();
+
                     // Adjust style properties so the window appears in the middle of the screen rather than very top
-                    setup.element[0].style.top = setup.element[0].style.left = ""
-                    setup.setPosition({height: "auto"});
+                    setup.element[0].style.top = setup.element[0].style.left =
+                        "";
+                    setup.setPosition({ height: "auto" });
                 });
-                if (ForgeVTT.utils.isNewerVersion(ForgeVTT.foundryVersion, "11")) {
+
+                if (
+                    ForgeVTT.utils.isNewerVersion(ForgeVTT.foundryVersion, "11")
+                ) {
                     // v11 requires that we export worlds before migration if on Forge so that we can set deleteNEDB
                     // This removes unused NEDB databases from pre-v11 worlds which would otherwise swell user data use
                     Hooks.on("renderSetupPackages", (setup, html) => {

--- a/forgevtt-module.js
+++ b/forgevtt-module.js
@@ -305,12 +305,15 @@ class ForgeVTT {
                     };
 
                 if (
+                    ForgeVTT.utils.isNewerVersion(ForgeVTT.foundryVersion, "13")
+                ) {
+                    // In v13+, we instead need to patch `game` to override its post method.
+                    game.post = preparePostOverride(game.post);
+                } else if (
                     ForgeVTT.utils.isNewerVersion(ForgeVTT.foundryVersion, "9")
                 ) {
                     // For v9-v12, we can patch the Setup class to override its post method.
-                    // In v13+, we instead need to patch `game`.
-                    const setup = Setup || game;
-                    setup.post = preparePostOverride(setup.post);
+                    Setup.post = preparePostOverride(Setup.post);
                 }
 
                 // Remove Configuration tab from /setup page


### PR DESCRIPTION
## Intent

This changeset adds support for our modifications to the Setup class's `post` method on Foundry's Setup view in v13. It also adds an `.editorconfig`, as my editor kept trying to turn four spaces into two :sweat_smile: 