### PR TITLE
Fix: Replacing "Begin Migration" with "Export Backup"

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -170,24 +170,24 @@ export class ForgeVTT {
         for (const klass of [foundry.abstract.Document, foundry.documents.BaseActor, foundry.documents.BaseMacro]) {
           const preCreate = klass.prototype._preCreate;
           klass.prototype._preCreate = async function (data, _options, _user) {
-            await ForgeVTT.findAndDestroyDataImages(this.documentName, data).catch(() => {});
+            await ForgeVTT.findAndDestroyDataImages(this.documentName, data).catch(() => { });
             return preCreate.call(this, ...arguments);
           };
           const preUpdate = klass.prototype._preUpdate;
           klass.prototype._preUpdate = async function (changed, _options, _user) {
-            await ForgeVTT.findAndDestroyDataImages(this.documentName, changed).catch(() => {});
+            await ForgeVTT.findAndDestroyDataImages(this.documentName, changed).catch(() => { });
             return preUpdate.call(this, ...arguments);
           };
         }
       } else if (ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "0.7.0")) {
         const create = Entity.create;
         Entity.create = async function (data, _options) {
-          await ForgeVTT.findAndDestroyDataImages(this.entity, data).catch(() => {});
+          await ForgeVTT.findAndDestroyDataImages(this.entity, data).catch(() => { });
           return create.call(this, ...arguments);
         };
         const update = Entity.update;
         Entity.update = async function (data, _options) {
-          await ForgeVTT.findAndDestroyDataImages(this.entity, data).catch(() => {});
+          await ForgeVTT.findAndDestroyDataImages(this.entity, data).catch(() => { });
           return update.call(this, ...arguments);
         };
       }
@@ -322,7 +322,10 @@ export class ForgeVTT {
                     return;
                   }
                   // Find the "Begin Migration" button and hide it initially
-                  const beginMigrationButton = ForgeVTT.ensureIsJQuery(dialogHtml).find(".dialog-button.yes");
+                  const beginMigrationButton = ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "13") ?
+                    ForgeVTT.ensureIsJQuery(dialogHtml).find("button[data-action='yes']")
+                    :  // v12 and older
+                    ForgeVTT.ensureIsJQuery(dialogHtml).find(".dialog-button.yes");
                   beginMigrationButton.hide();
                   // Create and prepend an "Export Backup to Migrate" button
                   const exportBackupButton = $(


### PR DESCRIPTION
This PR adds the correct check to find the "Begin Migration" button based on the Foundry version. 