### PR TITLE
Perform FilePicker initialization earlier

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -12,6 +12,9 @@ export class ForgeVTT {
     this.UPLOAD_API_ENDPOINT = `https://upload.${ForgeVTT.DOMAIN}`;
     this.FORGE_URL = `https://${this.HOSTNAME}`;
     this.ASSETS_LIBRARY_URL_PREFIX = "https://assets.forge-vtt.com/";
+
+    ForgeCompatibility.prepareFilePicker();
+
     if (this.usingTheForge) {
       // Welcome!
       //console.log(THE_FORGE_ASCII_ART);
@@ -105,8 +108,6 @@ export class ForgeVTT {
       default: "",
       type: String,
     });
-
-    ForgeCompatibility.prepareFilePicker();
 
     // Fix critical 0.6.6 bug
     if (ForgeVTT.foundryVersion === "0.6.6") {

--- a/src/applications/ForgeVTTFilePicker.mjs
+++ b/src/applications/ForgeVTTFilePicker.mjs
@@ -563,21 +563,12 @@ export class ForgeVTT_FilePicker extends FilePicker {
       source = "forgevtt";
     }
 
-    // If we need to route through Forge assets library
-    if (source === "forgevtt" || source === "forge-bazaar") {
-      return ForgeVTTFilePickerCore.browseForgeAssets(
-        source,
-        target,
-        options,
-        (s, t, o) => super.browse(s, t, o) // Pass the method reference properly
-      );
-    }
-
-    return super.browse(source, target, options).catch((err) => {
-      if (options._forgePreserveSource) {
-        throw err;
-      }
-    });
+    return ForgeVTTFilePickerCore.browseForgeAssets(
+      source,
+      target,
+      options,
+      (s, t, o) => super.browse(s, t, o) // Pass the method reference properly
+    );
   }
 
   /**

--- a/src/applications/ForgeVTTFilePicker.mjs
+++ b/src/applications/ForgeVTTFilePicker.mjs
@@ -573,7 +573,11 @@ export class ForgeVTT_FilePicker extends FilePicker {
       );
     }
 
-    return super.browse(source, target, options);
+    return super.browse(source, target, options).catch((err) => {
+      if (options._forgePreserveSource) {
+        throw err;
+      }
+    });
   }
 
   /**

--- a/src/applications/ForgeVTTFilePickerV2.mjs
+++ b/src/applications/ForgeVTTFilePickerV2.mjs
@@ -602,21 +602,12 @@ try {
           source = "forgevtt";
         }
 
-        // If we need to route through Forge assets library
-        if (source === "forgevtt" || source === "forge-bazaar") {
-          return ForgeVTTFilePickerCore.browseForgeAssets(
-            source,
-            target,
-            options,
-            (s, t, o) => super.browse(s, t, o) // Pass the method reference properly
-          );
-        }
-
-        return super.browse(source, target, options).catch((err) => {
-          if (options._forgePreserveSource) {
-            throw err;
-          }
-        });
+        return ForgeVTTFilePickerCore.browseForgeAssets(
+          source,
+          target,
+          options,
+          (s, t, o) => super.browse(s, t, o) // Pass the method reference properly
+        );
       }
 
       /**

--- a/src/applications/ForgeVTTFilePickerV2.mjs
+++ b/src/applications/ForgeVTTFilePickerV2.mjs
@@ -612,7 +612,11 @@ try {
           );
         }
 
-        return super.browse(source, target, options);
+        return super.browse(source, target, options).catch((err) => {
+          if (options._forgePreserveSource) {
+            throw err;
+          }
+        });
       }
 
       /**

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,8 +1,11 @@
 import { ForgeVTT } from "./ForgeVTT.mjs";
 import { ForgeAPI } from "./ForgeAPI.mjs";
+import { ForgeCompatibility } from "./ForgeCompatibility.mjs";
 import "./hooks.mjs";
 
 ForgeVTT.setupForge();
 
 globalThis.ForgeVTT = ForgeVTT;
 globalThis.ForgeAPI = ForgeAPI;
+globalThis.ForgeCompatibility = ForgeCompatibility;
+globalThis.ForgeVTT_FilePicker = ForgeCompatibility.FilePicker;

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
     sourcemap: true,
   },
   esbuild: {
+    minifyIdentifiers: false,
     banner: `/**
  * Copyright (C) 2021-${currentYear} - The Forge VTT Inc.
  * Author: Youness Alaoui <kakaroto@forge-vtt.com>


### PR DESCRIPTION
Fixes issues with some modules (Tokenizer, DDB-Importer) which also modify/interact with the FilePicker early in the app lifecycle.