### PR TITLE
2607 appv2 filepicker follow up

### DIFF
--- a/src/applications/ForgeVTTFilePicker.mjs
+++ b/src/applications/ForgeVTTFilePicker.mjs
@@ -15,13 +15,6 @@ export class ForgeVTT_FilePicker extends FilePicker {
     super(...args);
 
     /**
-     * Whether this is an older FilePicker implementation (v0.5.5 and back)
-     * @type {boolean}
-     * @private
-     */
-    this._classicFilePicker = !ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "0.5.5");
-
-    /**
      * Flag indicating whether we need to populate Forge buckets after initialization
      * @type {boolean}
      * @private
@@ -267,63 +260,6 @@ export class ForgeVTT_FilePicker extends FilePicker {
     ForgeVTTFilePickerCore.setURLQuery(input[0], query, value);
   }
 
-  /**
-   * Used for pre-0.5.6 foundry versions to create a new folder
-   * @param ev
-   * @param _ev
-   * @private
-   */
-  _onNewFolder(_ev) {
-    if (this.activeSource !== "forgevtt") {
-      return;
-    }
-
-    if (ForgeVTT_FilePicker._newFolderDialog) {
-      ForgeVTT_FilePicker._newFolderDialog.close();
-    }
-
-    const target = this.source.target;
-    ForgeVTT_FilePicker._newFolderDialog = new Dialog({
-      title: "Create New Assets Folder",
-      content: `
-        <div class="form-group stacked">
-          <label>Enter the name of the folder you want to create : </label>
-          <input type="text" name="folder-name"/>
-        </div>
-      `,
-      buttons: {
-        ok: {
-          label: "Create Folder",
-          icon: '<i class="fas fa-folder-plus"></i>',
-          callback: async (html) => {
-            const name = ForgeVTT.ensureIsJQuery(html).find('input[name="folder-name"]').val().trim();
-
-            const path = `${target}/${name}`;
-            if (!name) {
-              return;
-            }
-
-            const response = await ForgeAPI.call(
-              "assets/new-folder",
-              { path },
-              ForgeVTTFilePickerCore.bucketToCallOptions(this.source.bucket)
-            );
-
-            if (!response || response.error) {
-              ui.notifications.error(response ? response.error : "An unknown error occurred accessing The Forge API");
-            } else if (response.success) {
-              ui.notifications.info("Folder created successfully");
-              this.browse(path);
-            }
-          },
-        },
-        cancel: { label: "Cancel" },
-      },
-      default: "ok",
-      close: (_html) => {},
-    }).render(true);
-  }
-
   /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
@@ -386,55 +322,27 @@ export class ForgeVTT_FilePicker extends FilePicker {
     input.on("input", this._onInputChange.bind(this, options, input));
     this._onInputChange(options, input);
 
-    // Handle different FilePicker versions
-    if (this._classicFilePicker) {
-      // Handle older Foundry versions
-      if (this.constructor._newFolderDialog) {
-        this.constructor._newFolderDialog.close();
-        this.constructor._newFolderDialog = null;
-      }
+    if (["forgevtt", "forge-bazaar"].includes(this.activeSource)) {
+      html.find(`button[data-action="toggle-privacy"]`).remove();
+      html.find(".form-group.bucket label").text("Select source");
+    }
 
-      if (this.activeSource === "forgevtt") {
-        const upload = html.find("input[name=upload]");
-        const uploadDiv = $(`
-          <div class="form-group">
-            <button type="button" name="forgevtt-upload" style="line-height: 1rem;">
-              <i class="fas fa-upload"></i>Choose File
-            </button>
-            <button type="button" name="forgevtt-new-folder" style="line-height: 1rem;">
-              <i class="fas fa-folder-plus"></i>New Folder
-            </button>
-          </div>
-        `);
-
-        upload.hide();
-        upload.after(uploadDiv);
-        uploadDiv.append(upload);
-        uploadDiv.find('button[name="forgevtt-upload"]').on("click", (_ev) => upload.click());
-        uploadDiv.find('button[name="forgevtt-new-folder"]').on("click", (_ev) => this._onNewFolder());
-      }
-    } else {
-      if (["forgevtt", "forge-bazaar"].includes(this.activeSource)) {
-        html.find(`button[data-action="toggle-privacy"]`).remove();
-        html.find(".form-group.bucket label").text("Select source");
-      }
-
-      // Handle image thumbnails
-      const images = html.find("img");
-      for (const img of images.toArray()) {
-        if (!img.src && img.dataset.src && img.dataset.src.startsWith(ForgeVTT.ASSETS_LIBRARY_URL_PREFIX)) {
-          try {
-            // Ask server to thumbnail the image to make display of large scene background
-            // folders easier
-            const url = new URL(img.dataset.src);
-            url.searchParams.set("height", "200");
-            img.dataset.src = url.href;
-          } catch (error) {
-            console.error(error);
-          }
+    // Handle image thumbnails
+    const images = html.find("img");
+    for (const img of images.toArray()) {
+      if (!img.src && img.dataset.src && img.dataset.src.startsWith(ForgeVTT.ASSETS_LIBRARY_URL_PREFIX)) {
+        try {
+          // Ask server to thumbnail the image to make display of large scene background
+          // folders easier
+          const url = new URL(img.dataset.src);
+          url.searchParams.set("height", "200");
+          img.dataset.src = url.href;
+        } catch (error) {
+          console.error(error);
         }
       }
     }
+    // }
 
     // Set up the bucket select
     const select = html.find('select[name="bucket"]');

--- a/src/applications/ForgeVTTFilePicker.mjs
+++ b/src/applications/ForgeVTTFilePicker.mjs
@@ -75,8 +75,7 @@ export class ForgeVTT_FilePicker extends FilePicker {
    * @private
    */
   _inferCurrentDirectoryAndSetSource(target) {
-    const superInferFn = (t) => super._inferCurrentDirectory(t);
-    const [source, assetPath, bucketKey] = ForgeVTTFilePickerCore.inferForgeDirectory(target, superInferFn);
+    const [source, assetPath, bucketKey] = this._inferCurrentDirectory(target);
 
     // Set activeSource and target
     this.activeSource = source;
@@ -475,7 +474,7 @@ export class ForgeVTT_FilePicker extends FilePicker {
       source,
       target,
       options,
-      (s, t, o) => super.browse(s, t, o) // Pass the method reference properly
+      super.browse // Pass a reference to the super class method
     );
   }
 
@@ -505,7 +504,7 @@ export class ForgeVTT_FilePicker extends FilePicker {
       source,
       target,
       options,
-      (s, t, o) => super.createDirectory(s, t, o) // Pass the method reference properly
+      super.createDirectory // Pass a reference to the super class method
     );
   }
 
@@ -523,17 +522,18 @@ export class ForgeVTT_FilePicker extends FilePicker {
         file,
         {}, // Empty body
         { notify: body }, // Older versions passed notify directly as param
-        (s, t, f, b, _o) => super.upload(s, t, f, b) // Original takes 4 params
+        super.upload // Pass a reference to the super class method
       );
     }
 
+    // v12 and newer use different parameters
     return ForgeVTTFilePickerCore.uploadToForge(
       source,
       target,
       file,
       body,
       options,
-      (s, t, f, b, o) => super.upload(s, t, f, b, o) // Newer v12 takes 5 params
+      super.upload // Pass a reference to the super class method
     );
   }
 

--- a/src/utils/ForgeVTTFilePickerCore.mjs
+++ b/src/utils/ForgeVTTFilePickerCore.mjs
@@ -225,20 +225,19 @@ export class ForgeVTTFilePickerCore {
    */
   static inferForgeDirectory(target, superInferFn) {
     const buckets = this.getForgeVTTBuckets();
+    if (buckets.length === 0) {
+      // No buckets, so no assets library access
+      return superInferFn(target);
+    }
+
+    let userBucket = buckets[0];
+    let userBucketKey = this.getBucketKey(
+      userBucket,
+      buckets,
+      ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "12")
+    );
 
     if (!target) {
-      if (buckets.length === 0) {
-        // No buckets, so no assets library access
-        return superInferFn(target);
-      }
-
-      const userBucket = buckets[0];
-      const userBucketKey = this.getBucketKey(
-        userBucket,
-        buckets,
-        ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "12")
-      );
-
       return ["forgevtt", "", userBucketKey];
     }
 
@@ -259,9 +258,9 @@ export class ForgeVTTFilePickerCore {
       const forgePath = `${decodeURIComponent(parts.slice(1, -1).join("/"))}/`;
 
       // Check if this is the user's own asset
-      const userBucket = buckets.find((b) => b.userId === userId);
+      userBucket = buckets.find((b) => b.userId === userId);
       if (userBucket) {
-        const userBucketKey = this.getBucketKey(
+        userBucketKey = this.getBucketKey(
           userBucket,
           buckets,
           ForgeCompatibility.isNewerVersion(ForgeVTT.foundryVersion, "12")


### PR DESCRIPTION
Follow up to #56.
- Removes unused code for Foundry 0.5.X
- Simplify function reference passing
- Restore handling for inferring directory when there is a target but no buckets