### PR TITLE
Fix a reference to `ForgeVTT.utils.isNewerVersion`

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -266,7 +266,7 @@ export class ForgeVTT {
             // v11 checks the response manifest against what is passed
             manifest: data.manifest,
           };
-          if (ForgeVTT.utils.isNewerVersion(ForgeVTT.foundryVersion, "13")) {
+          if (ForgeVTT.isFoundryNewerThan("13")) {
             // In v13 we need to manually reload for the package list to update
             this.reload();
           } else {


### PR DESCRIPTION
## Intent

This changeset fixes a check for if the user is on Foundry v13+ when installing or updating packages. Previously, we were using `ForgeVTT.utils.isNewerVersion`; the appropriate way to do so now is `ForgeVTT.isFoundryNewerThan`.