### PR TITLE
WIP: Update LiveKit server registration for Foundry 13 / LiveKit 0.6.X

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -801,15 +801,25 @@ export class ForgeVTT {
       const liveKitModuleVersion = isNewerThanV10 ? liveKitModule.version : liveKitModule.data.version;
       if (ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.5")) {
         // hook on liveKitClientAvailable in 0.5.2+ as it gets called earlier and fixes issues seeing the Forge option if A/V isn't enabled yet
-        const hookName = ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.5.1")
-          ? "liveKitClientAvailable"
-          : "liveKitClientInitialized";
+        let hookName;
+        if (ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.6.0")) {
+          hookName = "ready";
+        } else if (ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.5.1")) {
+          hookName = "liveKitClientAvailable";
+        } else {
+          hookName = "liveKitClientInitialized";
+        }
         // Foundry creates the client and connects it immediately without any hooks or anything to let us act on it
         // So we need to set this up on the client class itself in the setup hook before webrtc is configured
         Hooks.once(hookName, (client) => {
-          const liveKitClient = ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.5.1")
-            ? client
-            : client._liveKitClient;
+          let liveKitClient;
+          if (ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.6.0")) {
+            liveKitClient = game.webrtc.client._liveKitClient;
+          } else if (ForgeCompatibility.isNewerVersion(liveKitModuleVersion, "0.5.1")) {
+            liveKitClient = client;
+          } else {
+            liveKitClient = client._liveKitClient;
+          }
           liveKitClient.addLiveKitServerType({
             key: "forge",
             label: "The Forge",


### PR DESCRIPTION
Update how we register The Forge's LiveKit server for Foundry v13 / LiveKit 0.6.X.

So far, this does allow selecting The Forge in the A/V server configuration, but does not yet allow actually connecting to the server.
<img width="769" height="676" alt="image" src="https://github.com/user-attachments/assets/8c7f1e72-462f-4965-b209-25a47ab81416" />

Error when attempting to connect on login:
<img width="611" height="252" alt="image" src="https://github.com/user-attachments/assets/4650fab1-d93a-4131-9284-40d9e1b42261" />

Errors when attempting to manually turn on audio/video streaming (in the A/V dock):
<img width="611" height="171" alt="image" src="https://github.com/user-attachments/assets/1a7f7148-4cc9-4943-a451-9b7f1aca1824" />
