### PR TITLE
Changes the "Export Backup" button to <button> rather than <a>

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -370,9 +370,9 @@ export class ForgeVTT {
             beginMigrationButton.hide();
             // Create and prepend an "Export Backup to Migrate" button
             const exportBackupButton = $(
-              `<a class="button" href="#"><i class="fa-solid fa-download"></i>${game.i18n.localize(
+              `<button class="dialog-button yes"><i class="fa-solid fa-download"></i>${game.i18n.localize(
                 "THEFORGE.MigrationExportBackup"
-              )}</a>`
+              )}</button>`
             );
             exportBackupButton.on("click", async () => {
               exportBackupButton.off("click");


### PR DESCRIPTION
Updated the inserted button for exporting backups to be a `<button>` like the other buttons in the dialog rather than an anchor in order to match layout and styling.