### PR TITLE
Restore the "Join Game As" button in the main menu on v13

### DIFF
--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -530,15 +530,15 @@ export class ForgeVTT {
 
       if (ForgeAPI.lastStatus.autojoin) {
         if (ForgeVTT.isFoundryNewerThan("13")) {
-          // Remove the original "Log Out" button. We can't just `.off("click")` as of v13, because Foundry's
-          //   click handler is on the whole menu, not just the item
-          jqHtml.find("li[data-menu-item='logout']").remove();
           // Add "Join Game As" button to the main menu, just before the "User Management" item
           $(
             `<li class="menu-item flexrow" data-menu-item="forge-join-as"><i class="fas fa-random"></i><h2>Join Game As</h2></li>`
-          ).insertBefore("li[data-menu-item='players']");
+          ).insertBefore("li[data-menu-item='logout']");
           // Find the element we just added so the click handler doesn't get applied to the whole menu
           jqHtml.find("li[data-menu-item='forge-join-as']").on("click", () => this._joinGameAs());
+          // Remove the original "Log Out" button. We can't just `.off("click")` as of v13, because Foundry's
+          //   click handler is on the whole menu, not just the item
+          jqHtml.find("li[data-menu-item='logout']").remove();
         } else {
           const join = jqHtml.find("li.menu-logout").removeClass("menu-logout").addClass("menu-join-as");
           // Don't use game.user.isGM because we could be logged in as a player


### PR DESCRIPTION
## Intent
This changeset restores a button on the main menu for non-GM users.