### PR TITLE
Added compatibility shim for CONST.CHAT_MESSAGE_TYPES/_STYLES

### DIFF
--- a/src/ForgeCompatibility.mjs
+++ b/src/ForgeCompatibility.mjs
@@ -44,6 +44,13 @@ export class ForgeCompatibility {
     return Module;
   }
 
+  static get chatMessageStyles() {
+    if (ForgeVTT.isFoundryNewerThan("12")) {
+      return CONST.CHAT_MESSAGE_STYLES;
+    }
+    return CONST.CHAT_MESSAGE_TYPES;
+  }
+
   static get mergeObject() {
     if (ForgeVTT.isFoundryNewerThan("11")) {
       return foundry.utils.mergeObject;

--- a/src/ForgeVTT.mjs
+++ b/src/ForgeVTT.mjs
@@ -1426,7 +1426,7 @@ export class ForgeVTT {
       return;
     }
     // OTHER type chat messages from other users should also be ignored
-    if (message?.type === CONST.CHAT_MESSAGE_TYPES.OTHER) {
+    if (message?.type === ForgeCompatibility.chatMessageStyles.OTHER) {
       return;
     }
     this._onServerActivityEvent();


### PR DESCRIPTION
Added a new compatibility shim for  `CONST.CHAT_MESSAGE_TYPES`/ `CONST.CHAT_MESSAGE_STYLES` which had its name changed.

Resolves part of https://github.com/ForgeVTT/theforge/issues/2694
> Error messages displayed after leaving messages on chat This error was displayed on console when performing a chat between Game Master and a Player User.