### PR TITLE
Add option to skip syncing assets for installed systems and modules

### DIFF
--- a/public/assets-sync.js
+++ b/public/assets-sync.js
@@ -51,7 +51,7 @@ class ForgeAssetSync {
 
     constructor(
         app = null,
-        { forceLocalRehash = false, overwriteLocalMismatches = false, updateFoundryDb = false } = {}
+        { forceLocalRehash = false, overwriteLocalMismatches = false, updateFoundryDb = false, skipInstalledPackages = false } = {}
     ) {
         // Number of retries to perform for error-prone operations
         this.retries = 2;
@@ -82,6 +82,12 @@ class ForgeAssetSync {
 
         // Dictates if the local game database needs to be rewritten to use local assets
         this.updateFoundryDb = updateFoundryDb;
+
+        // Dictates if assets belonging to installed systems/modules should be skipped (they are recreated on package install)
+        this.skipInstalledPackages = skipInstalledPackages;
+
+        // Set of installed module IDs, populated at the start of sync() when skipInstalledPackages is true
+        this._installedModuleIds = null;
 
         // Holds the current syncing status
         this.status = ForgeAssetSync.SYNC_STATUSES.READY;
@@ -144,8 +150,18 @@ class ForgeAssetSync {
 
         // 1. get Forge inventory
         const { forgeDirMap, forgeFileMap } = await this.buildForgeInventory();
-        const forgeDirSet = new Set(forgeDirMap.keys());
-        const forgeFileSet = new Set(forgeFileMap.keys());
+
+        // Build filtered maps for the sync pass, skipping assets that belong to installed packages.
+        // The full forgeFileMap is kept intact for the DB-rewrite step (WorldMigration), because
+        // skipped assets still exist locally after the package is installed and should still be
+        // remapped to their local paths.
+        this._installedModuleIds = new Set(game.modules.keys());
+        const syncDirMap = new Map([...forgeDirMap].filter(([k]) => !this._shouldSkipInstalledAsset(k)));
+        const syncFileMap = new Map([...forgeFileMap].filter(([k]) => !this._shouldSkipInstalledAsset(k)));
+        const skippedCount = forgeDirMap.size + forgeFileMap.size - (syncDirMap.size + syncFileMap.size);
+        if (skippedCount) console.log(`Forge VTT | Asset Sync: skipping ${skippedCount} assets/folders belonging to installed packages.`);
+
+        const forgeDirSet = new Set(syncDirMap.keys());
 
         if (this.status === ForgeAssetSync.SYNC_STATUSES.CANCELLED) return;
         // 2. Build Local inventory
@@ -184,7 +200,7 @@ class ForgeAssetSync {
             return this.updateMapFile();
         }
         this.setStatus(ForgeAssetSync.SYNC_STATUSES.SYNCING);
-        const { synced, failed } = await this.assetSyncProcessor(forgeFileMap, localFileSet);
+        const { synced, failed } = await this.assetSyncProcessor(syncFileMap, localFileSet);
 
         // logging/notification
         console.log(
@@ -228,6 +244,71 @@ class ForgeAssetSync {
         }
 
         this.setStatus(ForgeAssetSync.SYNC_STATUSES.COMPLETE);
+    }
+
+    /**
+     * Returns true if the asset at the given name should be skipped because it belongs to an installed
+     * system or module (those files are recreated locally when the package is installed).
+     * Always returns false when skipInstalledPackages is off, preserving the original behaviour.
+     * @param {string} name - the asset name as stored in forgeDirMap/forgeFileMap (may include apiKeyPath prefix)
+     * @returns {boolean}
+     */
+    _shouldSkipInstalledAsset(name) {
+        if (!this.skipInstalledPackages) {
+            return false;
+        }
+
+        // Strip the apiKeyPath prefix that buildForgeInventory prepends, then remove any leading slashes.
+        let path = name;
+        if (this.apiKeyPath && path.startsWith(this.apiKeyPath)) {
+            path = path.slice(this.apiKeyPath.length);
+        }
+        path = path.replace(/^\/+/, "");
+
+        // Only care about paths under modules/ or systems/
+        const match = path.match(/^(modules|systems)\/([^/]+)\/(.*)/);
+        if (!match) {
+            return false;
+        }
+
+        const [, type, id, rest] = match;
+
+        // Unknown module: sync it
+        if (type === "modules" && !this._installedModuleIds.has(id)) {
+            return false;
+        }
+        // Other/unknown system: sync it
+        if (type === "systems" && id !== game.system?.id) {
+            return false;
+        }
+
+        // Persistent-storage carve-out: always sync <type>/<id>/storage/... when the package
+        // declares persistentStorage: true in its manifest, because that data is not recreated on install.
+        if (rest.startsWith("storage/") && this._packageHasPersistentStorage(type, id)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the given package declares persistentStorage in its manifest.
+     * Reads the flag defensively to support multiple Foundry versions.
+     * @param {string} type - "modules" or "systems"
+     * @param {string} id   - the package id
+     * @returns {boolean}
+     */
+    _packageHasPersistentStorage(type, id) {
+        const pkg = type === "modules" ? game.modules?.get(id) : game.system;
+        // Foundry v12+ exposes pkg.flags.persistentStorage or pkg.persistentStorage directly.
+        // Older versions may nest it under pkg.data.persistentStorage or pkg.manifest.persistentStorage.
+        return !!(
+            pkg?.persistentStorage ??
+            pkg?.flags?.persistentStorage ??
+            pkg?.manifest?.persistentStorage ??
+            pkg?.data?.persistentStorage ??
+            false
+        );
     }
 
     async cancelSync() {
@@ -941,6 +1022,13 @@ class ForgeAssetSyncApp extends FormApplication {
                 htmlName: "update-foundry-db",
                 checked: false,
                 label: "Update Foundry World & Compendiums to use Local Assets",
+                disabled: false,
+            },
+            {
+                name: "skipInstalledPackages",
+                htmlName: "skip-installed-packages",
+                checked: true,
+                label: "Skip assets for installed systems & modules (recreated on install)",
                 disabled: false,
             },
         ];


### PR DESCRIPTION
Closes #24.

Adds an Asset Sync toggle (on by default) that skips downloading assets under `modules/<id>/` and `systems/<id>/` when `<id>` is an installed package, since those files are recreated locally on package install. Assets for packages that are not installed still sync. The persistent-storage carve-out (`<type>/<id>/storage/`) always syncs when the manifest sets `persistentStorage: true`. World and compendium database rewrites are unaffected, since they still receive the full asset map.

First iteration: systems are detected via `game.system.id` only. Multi-system detection via `FilePicker.browse` is left for a follow-up, as discussed in the issue.

## Test plan

Verified on Foundry v14.363 against a real Forge library of 39,542 assets, via a live Asset Sync run:

- [x] Toggle on: assets under installed `modules/<id>/` and the current `systems/<id>/` are skipped before any download. With four matching modules present in `game.modules` (764 + 25 + 9 + 4 assets), the console logged `skipping 802 assets/folders belonging to installed packages` and none of those folders received files.
- [x] Persistent-storage carve-out: with one of those modules declaring `persistentStorage: true`, the skip count dropped to 796, i.e. its six `storage/` entries synced instead of being skipped.
- [x] Packages not present in `game.modules`, and any non-current system, still sync. Paths outside `modules/`/`systems/` are never skipped.
- [x] Predicate spot-checked in the console against real installed packages (`game.modules` / `game.system.id`), including the apiKeyPath-prefix and `storage/` edge cases.
- [x] Toggle off: behaviour is identical to current (nothing skipped); the predicate short-circuits to false.